### PR TITLE
Fix bug when creating a sqlite database via Felis

### DIFF
--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -223,7 +223,8 @@ def create_database(connection_string, drop_tables=False, felis_schema=None):
 
         # Schema handling for various database types
         if connection_string.startswith("sqlite"):
-            db_name = connection_string.split("/")[-1]
+            # Get the full path to the file as otherwise the DB is only created in the working directory
+            db_name = connection_string.replace("sqlite:///", "")
             with engine.begin() as conn:
                 conn.execute(text(f"ATTACH '{db_name}' AS {schema_name}"))
         elif connection_string.startswith("postgres"):


### PR DESCRIPTION
The bug was that if a connection_string specified some directory structure, this was ignored when attaching the database. This meant that two copies of the file were created and one of them was completely empty of tables.