### PR TITLE
Updating view handling code; pinning sqlalchemy version

### DIFF
--- a/.github/workflows/test-dependencies.yml
+++ b/.github/workflows/test-dependencies.yml
@@ -1,0 +1,30 @@
+# This workflow will install the package on a regular schedule to check if there are any depenedency issues.
+
+name: Test Astrodbkit Dependencies
+
+on:
+  schedule:
+    - cron: '0 16 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          python-version: [3.11, 3.12, 3.13]
+
+      steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # install package and requirements
+          pip install ".[all]"
+      - name: Test with pytest
+        run: |
+          pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">= 3.11"
 dependencies = [
     "astropy",
     "astroquery",
-    "sqlalchemy==2.0.38",
+    "sqlalchemy>=2.0.38",
     "pandas>=1.0.4",
     "packaging",
     "specutils>=1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ requires-python = ">= 3.11"
 dependencies = [
     "astropy",
     "astroquery",
-    "sqlalchemy>=2.0",
+    "sqlalchemy==2.0.38",
     "pandas>=1.0.4",
     "packaging",
     "specutils>=1.0",


### PR DESCRIPTION
SQLAlchemy version 2.0.38, released 4 days ago, breaks how views were being handled. There is a new example of how to use them in https://github.com/sqlalchemy/sqlalchemy/wiki/Views so I've updated our code to match that. This now passes the tests.

This also pins the SQLAlchemy version to avoid similar situations in the future.