### PR TITLE
Pinning astroquery and updating code to handle astroquery 0.4.8 changes

### DIFF
--- a/astrodbkit/tests/test_utils.py
+++ b/astrodbkit/tests/test_utils.py
@@ -68,5 +68,4 @@ def test_get_simbad_names(mock_simbad):
 def test_get_simbad_names_live():
     """Unmocked version of the call to Simbad to catch API changes"""
     t = get_simbad_names("TWA 27")
-    print(len(t))
     assert "TIC 102076870" in t

--- a/astrodbkit/tests/test_utils.py
+++ b/astrodbkit/tests/test_utils.py
@@ -53,7 +53,7 @@ def test_datetime_json_parser():
 
 @mock.patch('astrodbkit.utils.Simbad.query_objectids')
 def test_get_simbad_names(mock_simbad):
-    mock_simbad.return_value = Table({'ID': ['name 1', 'name 2', 'V* name 3', 'HIDDEN name']})
+    mock_simbad.return_value = Table({'id': ['name 1', 'name 2', 'V* name 3', 'HIDDEN name']})
     t = get_simbad_names('twa 27')
     assert len(t) == 3
     assert t[2] == 'name 3'
@@ -63,3 +63,10 @@ def test_get_simbad_names(mock_simbad):
     t = get_simbad_names('WISEU J005559.88+594745.0')
     assert len(t) == 1
     assert t[0] == 'WISEU J005559.88+594745.0'
+
+
+def test_get_simbad_names_live():
+    """Unmocked version of the call to Simbad to catch API changes"""
+    t = get_simbad_names("TWA 27")
+    print(len(t))
+    assert "TIC 102076870" in t

--- a/astrodbkit/utils.py
+++ b/astrodbkit/utils.py
@@ -122,7 +122,7 @@ def get_simbad_names(name, verbose=False):
 
     t = Simbad.query_objectids(name)
     if t is not None and len(t) > 0:
-        temp = [_name_formatter(s) for s in t["ID"].tolist()]
+        temp = [_name_formatter(s) for s in t["id"].tolist()]
         return [s for s in temp if s is not None and s != ""]
     else:
         if verbose:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 ]
 requires-python = ">= 3.11"
 dependencies = [
-    "astropy",
+    "astropy>7.0",
     "astroquery>=0.4.9",
     "sqlalchemy>=2.0.38",
     "pandas>=1.0.4",
@@ -34,10 +34,10 @@ test = [
     "pytest",
     "pytest-cov",
     "pytest-astropy",
-    "darker==1.7.2",
-    "black==23.9.1",
-    "pre-commit==3.4.0",
-    "ruff==0.3.7",
+    "darker>=1.7.2",
+    "black>=23.9.1",
+    "pre-commit>=3.4.0",
+    "ruff>=0.3.7",
 ]
 docs = [
     "sphinx-astropy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
 requires-python = ">= 3.11"
 dependencies = [
     "astropy",
-    "astroquery",
+    "astroquery>=0.4.9",
     "sqlalchemy>=2.0.38",
     "pandas>=1.0.4",
     "packaging",


### PR DESCRIPTION
Astroquery 0.4.8 introduced a breaking change in the Simbad API by having all lower-case names. This fix updates that and pins the version being used.

Closes #90