### PR TITLE
Create alias for save method

### DIFF
--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -358,8 +358,9 @@ class Database:
                 connection_string, sqlite_foreign=sqlite_foreign, connection_arguments=connection_arguments
             )
 
-        # Convenience methods
+        # Convenience methods and aliases
         self.query = self.session.query
+        self.save = self.save_database
         self.save_db = self.save_database
         self.load_db = self.load_database
 

--- a/astrodbkit/tests/test_astrodb.py
+++ b/astrodbkit/tests/test_astrodb.py
@@ -450,7 +450,8 @@ def test_save_database(db, db_dir):
         elif os.path.isdir(file_path):
             shutil.rmtree(file_path)
 
-    db.save_database(db_dir)
+    # Can use db.save, db.save_db, or db.save_database
+    db.save(db_dir)
 
     # Check JSON data
     assert os.path.exists(os.path.join(db_dir, "reference", 'Publications.json'))


### PR DESCRIPTION
There was already a `db.save_db` alias, but I went ahead and added a new `db.save` one based on the issue. Also updated the test to confirm it works.

Closes #95